### PR TITLE
Fix IPTV Manager timeout issues

### DIFF
--- a/resources/lib/Yelo.py
+++ b/resources/lib/Yelo.py
@@ -45,8 +45,9 @@ class Yelo(YeloApi.YeloApi):
 
     def list_channels(self, is_folder=False):
         from resources.lib.kodiwrapper import KodiWrapper
-        import dateutil.parser
         import datetime
+        import dateutil.parser
+        from dateutil.tz import UTC
 
         listing = []
 
@@ -63,7 +64,7 @@ class Yelo(YeloApi.YeloApi):
 
             for index, item in enumerate(epg[name]):
                 try:
-                    now = datetime.datetime.utcnow().replace(second=0, microsecond=0)
+                    now = datetime.datetime.utcnow().replace(second=0, microsecond=0, tzinfo=UTC)
                     start = dateutil.parser.parse(item["start"])
                     end = dateutil.parser.parse(item["stop"])
 

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -27,13 +27,13 @@ def play(uniqueName):
 def iptv_channels():
     from resources.lib.iptvmanager import IPTVManager
     port = int(plugin.args['port'][0])
-    IPTVManager(port).send_channels(yelo)
+    IPTVManager(port, yelo).send_channels()
 
 @plugin.route('/iptv/epg')
 def iptv_epg():
     from resources.lib.iptvmanager import IPTVManager
     port = int(plugin.args['port'][0])
-    IPTVManager(port).send_epg(yelo)
+    IPTVManager(port, yelo).send_epg()
 
 def run():
     plugin.run()

--- a/resources/lib/helpers/helpermethods.py
+++ b/resources/lib/helpers/helpermethods.py
@@ -167,4 +167,4 @@ def create_token(size):
 
 def timestamp_to_datetime(timestamp):
     from datetime import datetime
-    return datetime.utcfromtimestamp(timestamp).strftime("%Y-%m-%dT%H:%M:%S")
+    return datetime.utcfromtimestamp(timestamp).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
This PR includes:
- A fix to open the socket to IPTV Manager as quickly as possible
- Fix the timezone offset information so IPTV Simple add-on loads the EPG fully

This fixes add-ons/service.iptv.manager#23

