### PR TITLE
Fix deprecated RunScript

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,6 +6,7 @@ disable=
     import-outside-toplevel,  # Done on purpose to reduce overhead at startup
     missing-docstring,  # TODO
     old-style-class,
+    super-with-arguments,
     too-few-public-methods,
     too-many-arguments,
     too-many-branches,

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 import routing
 
-from sys import argv
 from helpers.helperclasses import EPG
 from yelo_exceptions import YeloException
 from yelo import Yelo
@@ -30,8 +29,8 @@ def main_menu():
 def play_id(channel_id):
     try:
         yelo.play(channel_id)
-    except YeloException as e:
-        _LOGGER.error(e)
+    except YeloException as exc:
+        _LOGGER.error(exc)
 
 
 @plugin.route('/iptv/channels')

--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -52,3 +52,7 @@ def run(argv):
     plugin.run(argv)
 
 
+@plugin.route('/epg/refresh')
+def epg_refresh():
+    from yelo_bg_service import refresh_epg
+    refresh_epg()

--- a/resources/lib/addon_entry.py
+++ b/resources/lib/addon_entry.py
@@ -7,5 +7,4 @@ from addon import run
 
 
 if __name__ == '__main__':
-    function = argv[1]
     run(argv)

--- a/resources/lib/addon_entry.py
+++ b/resources/lib/addon_entry.py
@@ -6,22 +6,6 @@ from sys import argv
 from addon import run
 
 
-def refresh_EPG():
-    from kodiwrapper import KodiWrapper
-    from yelo_bg_service import BackgroundService
-
-    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),
-                          KodiWrapper.get_localized_string(40003))
-
-    BackgroundService.cache_channel_epg()
-    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),
-                          KodiWrapper.get_localized_string(40002))
-
-
 if __name__ == '__main__':
     function = argv[1]
-
-    if function == "refresh_epg":
-        refresh_EPG()
-    else:
-        run(argv)
+    run(argv)

--- a/resources/lib/helpers/helperclasses.py
+++ b/resources/lib/helpers/helperclasses.py
@@ -81,7 +81,7 @@ class EPG:
         self.epg = Addon().getSetting('epg')
 
 
-class PluginCache:
+class PluginCache:  # pylint: disable=no-init
     CACHE_FILE_NAME = "data.json"
 
     @classmethod
@@ -133,5 +133,3 @@ class PluginCache:
             data = json.load(json_file)
 
         return data.get(key)
-
-

--- a/resources/lib/kodiwrapper.py
+++ b/resources/lib/kodiwrapper.py
@@ -88,5 +88,3 @@ class KodiWrapper():  # pylint: disable=no-init
     @classmethod
     def set_setting(cls, name, value):
         Addon().setSetting(name, value)
-
-

--- a/resources/lib/yelo.py
+++ b/resources/lib/yelo.py
@@ -2,15 +2,15 @@
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, unicode_literals
+import logging
 import inputstreamhelper
 import xbmcgui
 import xbmcplugin
-import logging
 
 from data import USER_AGENT
 from helpers.helperclasses import PluginCache
 from helpers.helpermethods import widevine_payload_package
-from yelo_api import YeloApi, YeloException
+from yelo_api import YeloApi
 
 try:  # Python 3
     from urllib.parse import quote
@@ -26,9 +26,6 @@ _LOGGER = logging.getLogger('plugin')
 
 
 class Yelo(YeloApi):
-    def __init__(self):
-        super(Yelo, self).__init__()
-
     def play(self, channel):
         manifest_url = self.get_manifest(channel)
         device_id = PluginCache.get_by_key("device_id")

--- a/resources/lib/yelo_bg_service.py
+++ b/resources/lib/yelo_bg_service.py
@@ -47,6 +47,14 @@ class BackgroundService(Monitor):
             KodiWrapper.container_refresh()
 
 
+def refresh_epg():
+    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),
+                          KodiWrapper.get_localized_string(40003))
+    BackgroundService.cache_channel_epg()
+    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),
+                          KodiWrapper.get_localized_string(40002))
+
+
 def run():
     """ Run the BackgroundService """
     BackgroundService().run()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,7 +9,7 @@
 
     <category label="31998">
         <setting label="31999" type="bool" id="epg" default="true"/>
-        <setting label="40000" type="action" action="RunScript(plugin.video.yelo, refresh_epg)"/>
+        <setting label="40000" type="action" action="RunPlugin(plugin://plugin.video.yelo/epg/refresh)"/>
     </category>
 
     <category label="30860">


### PR DESCRIPTION
This fixes the deprecated call to RunScript which appears in the Kodi log.

```log
WARNING: RunScript called for a non-script addon 'plugin.video.yelo'.  This behaviour is deprecated.
```

It also fixes various issues introduced in 8a65e9040e50b6c7b56450d512710b4c67b9720a