### PR TITLE
Ensure no windows are shown when non-interactive

### DIFF
--- a/resources/lib/addon.py
+++ b/resources/lib/addon.py
@@ -5,30 +5,27 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 import routing
 
-from helpers.helperclasses import EPG
-from yelo_exceptions import YeloException
-from yelo import Yelo
-
 logging.basicConfig()
 _LOGGER = logging.getLogger('plugin')
 plugin = routing.Plugin()  # pylint: disable=invalid-name
 
-# instantiate yelo object
-yelo = Yelo()  # pylint: disable=invalid-name
-
 
 @plugin.route('/')
 def main_menu():
+    from helpers.helperclasses import EPG
+    from yelo import Yelo
     if EPG().is_enabled and EPG().is_cached:
-        yelo.list_channels()
+        Yelo().list_channels()
     else:
-        yelo.list_channels_without_epg()
+        Yelo().list_channels_without_epg()
 
 
 @plugin.route('/play/id/<channel_id>')
 def play_id(channel_id):
+    from yelo import Yelo
+    from yelo_exceptions import YeloException
     try:
-        yelo.play(channel_id)
+        Yelo().play(channel_id)
     except YeloException as exc:
         _LOGGER.error(exc)
 
@@ -37,14 +34,14 @@ def play_id(channel_id):
 def iptv_channels():
     from iptvmanager import IPTVManager
     port = int(plugin.args['port'][0])
-    IPTVManager(port, yelo).send_channels()
+    IPTVManager(port).send_channels()
 
 
 @plugin.route('/iptv/epg')
 def iptv_epg():
     from iptvmanager import IPTVManager
     port = int(plugin.args['port'][0])
-    IPTVManager(port, yelo).send_epg()
+    IPTVManager(port).send_epg()
 
 
 def run(argv):

--- a/resources/lib/iptvmanager.py
+++ b/resources/lib/iptvmanager.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, unicode_literals
 import logging
 import socket
 import json
+from yelo import Yelo
 
 _LOGGER = logging.getLogger('iptv-manager')
 
@@ -13,10 +14,10 @@ _LOGGER = logging.getLogger('iptv-manager')
 class IPTVManager:
     """Interface to IPTV Manager"""
 
-    def __init__(self, port, yelo):
+    def __init__(self, port):
         """Initialize IPTV Manager object"""
         self.port = port
-        self.yelo = yelo
+        self.yelo = Yelo(interactive=False)
 
     def via_socket(func):  # pylint: disable=no-self-argument
         """Send the output of the wrapped function to socket"""

--- a/resources/lib/yelo_api.py
+++ b/resources/lib/yelo_api.py
@@ -52,7 +52,8 @@ class YeloApi:  # pylint: disable=useless-object-inheritance
     session.verify = VERIFY
     session.headers['User-Agent'] = USER_AGENT
 
-    def __init__(self):
+    def __init__(self, interactive=True):
+        self.interactive = interactive
         self.auth_tries = 0
         if not self.oauth_in_cache:
             self._execute_required_steps()
@@ -107,8 +108,11 @@ class YeloApi:  # pylint: disable=useless-object-inheritance
         creds = Credentials()
 
         if not creds.are_filled_in():
-            KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(32014),
-                                  KodiWrapper.get_localized_string(32015))
+            if not self.interactive:
+                raise NotAuthorizedException  # Do not ask for credentials when non-interactive, just fail
+
+            KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(32014),  # Login
+                                  KodiWrapper.get_localized_string(32015))  # Fill in your credentials
             KodiWrapper.open_settings()
             creds.reload()
 
@@ -127,8 +131,11 @@ class YeloApi:  # pylint: disable=useless-object-inheritance
                 PluginCache.set_data({"auth_token": token})
                 return True
         except NotAuthorizedException:
-            KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(32006),
-                                  KodiWrapper.get_localized_string(32007))
+            if not self.interactive:
+                raise  # Do not ask to check credentials when non-interactive, just fail
+
+            KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(32006),  # Login failed
+                                  KodiWrapper.get_localized_string(32007))  # Check your login details
 
             if self.auth_tries < 2:
                 KodiWrapper.open_settings()

--- a/resources/lib/yelo_bg_service.py
+++ b/resources/lib/yelo_bg_service.py
@@ -49,11 +49,11 @@ class BackgroundService(Monitor):
 
 
 def refresh_epg():
-    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),
-                          KodiWrapper.get_localized_string(40003))
+    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),  # Info
+                          KodiWrapper.get_localized_string(40003))  # This can take a while
     BackgroundService.cache_channel_epg()
-    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),
-                          KodiWrapper.get_localized_string(40002))
+    KodiWrapper.dialog_ok(KodiWrapper.get_localized_string(40001),  # Info
+                          KodiWrapper.get_localized_string(40002))  # EPG has been renewed
 
 
 def run():


### PR DESCRIPTION
We do not want to show any pop-up windows when IPTV Manager is
requesting channel and EPG information. If credentials fail, simply bail
out with an error.